### PR TITLE
Algorithm capabilities validator.

### DIFF
--- a/gen-val/samples/GenValAppRunner/src/Helpers/RunningOptionsHelper.cs
+++ b/gen-val/samples/GenValAppRunner/src/Helpers/RunningOptionsHelper.cs
@@ -30,6 +30,10 @@ namespace NIST.CVP.ACVTS.Generation.GenValApp.Helpers
         /// <param name="parsedParameters">The parsed command line arguments.</param>
         public static GenValMode DetermineRunningMode(ArgumentParsingTarget parsedParameters)
         {
+            if (parsedParameters.CapabilitiesFile != null)
+            {
+                return GenValMode.Check;
+            }
             if (parsedParameters.RegistrationFile != null)
             {
                 return GenValMode.Generate;
@@ -52,6 +56,9 @@ namespace NIST.CVP.ACVTS.Generation.GenValApp.Helpers
         {
             switch (genValMode)
             {
+                case GenValMode.Check:
+                    var capabilities = JsonConvert.DeserializeObject<ParametersBase>(File.ReadAllText(parsedParameters.CapabilitiesFile.FullName));
+                    return AlgoModeLookupHelper.GetAlgoModeFromStrings(capabilities.Algorithm, capabilities.Mode, capabilities.Revision);
                 case GenValMode.Generate:
                     var parameters = JsonConvert.DeserializeObject<ParametersBase>(File.ReadAllText(parsedParameters.RegistrationFile.FullName));
                     return AlgoModeLookupHelper.GetAlgoModeFromStrings(parameters.Algorithm, parameters.Mode, parameters.Revision);

--- a/gen-val/samples/GenValAppRunner/src/Models/ArgumentParsingTarget.cs
+++ b/gen-val/samples/GenValAppRunner/src/Models/ArgumentParsingTarget.cs
@@ -5,9 +5,13 @@ using System.IO;
 namespace NIST.CVP.ACVTS.Generation.GenValApp.Models
 {
     [DistinctGroupsCertification("g", "a,b",
-        Description = "(g) - used to indicate generation, (a,b) - used to indicate validation")]
+        Description = "(c) - used to indicate capabilities checker, (g) - used to indicate generation, (a,b) - used to indicate validation")]
     public class ArgumentParsingTarget
     {
+        [FileArgument('c', "capabilitiesFile", FileMustExist = true, Optional = true,
+            Description = "Specify the capabilities file to check parameter")]
+        public FileInfo CapabilitiesFile { get; set; }
+
         [FileArgument('g', "generationRequestFile", FileMustExist = true, Optional = true,
             Description = "Specify the test vector generation registration file")]
         public FileInfo RegistrationFile { get; set; }

--- a/gen-val/samples/GenValAppRunner/src/Program.cs
+++ b/gen-val/samples/GenValAppRunner/src/Program.cs
@@ -92,6 +92,9 @@ namespace NIST.CVP.ACVTS.Generation.GenValApp
 
             switch (runningOptions.GenValMode)
             {
+                case GenValMode.Check:
+                    filePath = parsedParameters.CapabilitiesFile.FullName;
+                    break;
                 case GenValMode.Generate:
                     filePath = parsedParameters.RegistrationFile.FullName;
                     break;

--- a/gen-val/samples/GenValAppRunner/test/GenValRunnerTests.cs
+++ b/gen-val/samples/GenValAppRunner/test/GenValRunnerTests.cs
@@ -64,6 +64,7 @@ namespace NIST.CVP.ACVTS.Libraries.Generation.GenValApp.Tests
         }
 
         [Test]
+        [TestCase(GenValMode.Check, "registration.json", null, null, StatusCode.Success)]
         [TestCase(GenValMode.Generate, "registration.json", null, null, StatusCode.Success)]
         [TestCase(GenValMode.Validate, null, "response.json", "answer.json", StatusCode.Success)]
         [TestCase(GenValMode.Unset, null, null, null, StatusCode.ModeError)]
@@ -71,6 +72,7 @@ namespace NIST.CVP.ACVTS.Libraries.Generation.GenValApp.Tests
         {
             var parameters = new ArgumentParsingTarget
             {
+                CapabilitiesFile = genValMode == GenValMode.Check ? new FileInfo(registrationFile) : null,
                 RegistrationFile = genValMode == GenValMode.Generate ? new FileInfo(registrationFile) : null,
                 ResponseFile = genValMode == GenValMode.Validate ? new FileInfo(responseFile) : null,
                 AnswerFile = genValMode == GenValMode.Validate ? new FileInfo(answerFile) : null

--- a/gen-val/samples/GenValAppRunner/test/RunningOptionsHelperTests.cs
+++ b/gen-val/samples/GenValAppRunner/test/RunningOptionsHelperTests.cs
@@ -11,12 +11,14 @@ namespace NIST.CVP.ACVTS.Libraries.Generation.GenValApp.Tests
     public class RunningOptionsHelperTests
     {
         [Test]
+        [TestCase(GenValMode.Check)]
         [TestCase(GenValMode.Generate)]
         [TestCase(GenValMode.Validate)]
         public void ShouldCorrectlySetRunningMode(GenValMode genValMode)
         {
             var parameters = new ArgumentParsingTarget
             {
+                CapabilitiesFile = genValMode == GenValMode.Check ? new FileInfo("registration.json") : null,
                 RegistrationFile = genValMode == GenValMode.Generate ? new FileInfo("registration.json") : null,
                 ResponseFile = genValMode == GenValMode.Validate ? new FileInfo("response.json") : null,
                 AnswerFile = genValMode == GenValMode.Validate ? new FileInfo("answer.json") : null

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation.Core/Enums/GenValMode.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation.Core/Enums/GenValMode.cs
@@ -3,6 +3,7 @@
     public enum GenValMode
     {
         Unset,
+        Check,
         Generate,
         Validate
     }


### PR DESCRIPTION
	The feature allows to validate algorithm capabilities without starting Orleans Server.
	Can be useful if need to check the algorithm parameters without starting the generation of vectors.
	How to use: dotnet run -c "path/to/registration.json"