### PR TITLE
Resolve bug #1591 - support null messages for 'inEmpty' tag

### DIFF
--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/SHA3/v1_0/TestCaseGeneratorAft.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/SHA3/v1_0/TestCaseGeneratorAft.cs
@@ -22,12 +22,13 @@ namespace NIST.CVP.ACVTS.Libraries.Generation.SHA3.v1_0
 
         public GenerateResponse PrepareGenerator(TestGroup group, bool isSample)
         {
+            _caseSizes = DetermineMessageLength(group.BitOrientedInput, group.CommonHashFunction.OutputLen);
+
             if (group.IncludeNull)
             {
                 _caseSizes.Add(0);
             }
 
-            _caseSizes = DetermineMessageLength(group.BitOrientedInput, group.CommonHashFunction.OutputLen);
             return new GenerateResponse();
         }
 


### PR DESCRIPTION
Resolve bug [#403](https://github.com/usnistgov/ACVP-Server/issues/403) to support null messages for 'inEmpty' tag