### PR TITLE
Add LargeZNorm disposition for ML-DSA sigVer

### DIFF
--- a/gen-val/src/crypto/src/NIST.CVP.ACVTS.Libraries.Crypto/Dilithium/Dilithium.cs
+++ b/gen-val/src/crypto/src/NIST.CVP.ACVTS.Libraries.Crypto/Dilithium/Dilithium.cs
@@ -307,7 +307,7 @@ public class Dilithium : ExternalSignatureBase, IMLDSA
     /// <param name="mu">64-byte message that has already been hashed</param>
     /// <param name="rnd">Either a random 32-byte string or 32-bytes of 0s</param>
     /// <returns>Signature</returns>
-    public byte[] SignExternalMu(byte[] sk, byte[] mu, byte[] rnd)
+    public virtual byte[] SignExternalMu(byte[] sk, byte[] mu, byte[] rnd)
     {
         var (rho, k, tr, s1, s2, t0) = SkDecode(sk);
         var s1Hat = s1.Select(NTT).ToArray();

--- a/gen-val/src/crypto/src/NIST.CVP.ACVTS.Libraries.Crypto/Dilithium/DilithiumLargeZNorm.cs
+++ b/gen-val/src/crypto/src/NIST.CVP.ACVTS.Libraries.Crypto/Dilithium/DilithiumLargeZNorm.cs
@@ -1,0 +1,163 @@
+using System.Linq;
+using NIST.CVP.ACVTS.Libraries.Crypto.Common.Hash.ShaWrapper;
+using NIST.CVP.ACVTS.Libraries.Crypto.Common.PQC.Dilithium;
+using NIST.CVP.ACVTS.Libraries.Math.Entropy;
+using NIST.CVP.ACVTS.Libraries.Math.Helpers;
+
+namespace NIST.CVP.ACVTS.Libraries.Crypto.Dilithium;
+
+/// <summary>
+/// An intentionally non-conformant ML-DSA signer used only for generating negative sigVer test cases.
+///
+/// FIPS 204 Algorithm 7 rejects a candidate signature when ||z|| >= Gamma1 - Beta. This signer inverts
+/// that half of the rejection: it keeps only candidates where ||z|| >= Gamma1 - Beta, while leaving the
+/// r0, ct0 and hint conditions in place. The resulting signature is internally consistent, so the
+/// commitment hash comparison in Verify passes, and the ||z|| bound in FIPS 204 Algorithm 8 becomes the
+/// only condition that rejects it. A mutation of an existing signature cannot produce this situation,
+/// because any change to z also changes w' and the commitment hash rejects the signature even in a
+/// verifier that omits the ||z|| check. See https://github.com/usnistgov/ACVP-Server/issues/462.
+///
+/// One extra constraint applies: SigEncode packs z coefficients into [-(Gamma1 - 1), Gamma1], and with
+/// the rejection disabled a candidate coefficient can reach Gamma1 + Beta. Candidates with any
+/// coefficient outside the encodable range are skipped so that SigDecode(SigEncode(sig)) round trips.
+///
+/// A candidate has ||z|| out of bound roughly 40 percent of the time; combined with the r0 condition
+/// and the representability guard, a usable candidate arrives within a handful of iterations.
+/// </summary>
+public class DilithiumLargeZNorm : Dilithium
+{
+    private readonly DilithiumParameters _param;
+    private readonly IShake _h;
+
+    public DilithiumLargeZNorm(DilithiumParameterSet param, IShaFactory shaFactory, IEntropyProvider entropyProvider = null)
+        : base(param, shaFactory, entropyProvider)
+    {
+        _param = new DilithiumParameters(param);
+        _h = shaFactory.GetShakeInstance(new HashFunction(ModeValues.SHAKE, DigestSizes.d256));
+    }
+
+    public override byte[] Sign(byte[] sk, byte[] m, byte[] rnd)
+    {
+        var (_, _, tr, _, _, _) = SkDecode(sk);
+
+        // Set up message representative, same as Dilithium.Sign()
+        var mu = new byte[64];
+        _h.Init();
+        _h.Update(BitsToBytes(tr), tr.Length);
+        _h.Update(m, m.Length * 8);
+        _h.Final(mu, 512);
+
+        return SignWithLargeZ(sk, mu, rnd);
+    }
+
+    public override byte[] SignExternalMu(byte[] sk, byte[] mu, byte[] rnd)
+    {
+        return SignWithLargeZ(sk, mu, rnd);
+    }
+
+    /// <summary>
+    /// The Dilithium.Sign() candidate loop with the ||z|| rejection inverted. Structure and naming
+    /// follow Dilithium.Sign() so the two are easy to diff; only the candidate acceptance differs.
+    /// </summary>
+    private byte[] SignWithLargeZ(byte[] sk, byte[] mu, byte[] rnd)
+    {
+        var (rho, k, _, s1, s2, t0) = SkDecode(sk);
+        var s1Hat = s1.Select(NTT).ToArray();
+        var s2Hat = s2.Select(NTT).ToArray();
+        var t0Hat = t0.Select(NTT).ToArray();
+        var aHat = ExpandA(rho);
+
+        var rhoPrime = new byte[64];
+        _h.Init();
+        _h.Update(BitsToBytes(k), k.Length);
+        _h.Update(rnd.ToArray(), rnd.Length * 8);
+        _h.Update(mu, mu.Length * 8);
+        _h.Final(rhoPrime, 512);
+        var rhoPrimeBits = BytesToBits(rhoPrime);
+
+        var kappa = 0;
+        var cTilde = new byte[(2 * _param.Lambda) / 8];
+        int[][] z;
+        int[][] h;
+
+        do
+        {
+            var y = ExpandMask(rhoPrimeBits, kappa);
+            var yHat = y.Select(NTT).ToArray();
+            var w = MatrixMultiply(aHat, yHat).Select(NTTInverse).ToArray();
+
+            var w1 = w.Select(polynomial => polynomial.Select(HighBits).ToArray()).ToArray();
+            var w1Encode = W1Encode(w1);
+
+            _h.Init();
+            _h.Update(mu, mu.Length * 8);
+            _h.Update(BitsToBytes(w1Encode), w1Encode.Length);
+            _h.Final(cTilde, 2 * _param.Lambda);
+
+            var c = SampleInBall(cTilde);
+            var cHat = NTT(c);
+
+            var cs1 = PairwiseMultiply(cHat, s1Hat).Select(NTTInverse).ToArray();
+            var cs2 = PairwiseMultiply(cHat, s2Hat).Select(NTTInverse).ToArray();
+            z = MatrixAdd(y, cs1);
+
+            var r0 = MatrixSubtract(w, cs2).Select(polynomial => polynomial.Select(LowBits).ToArray()).ToArray();
+
+            // Inverted from Dilithium.Sign(): keep the candidate only when ||z|| is out of bound. The
+            // representability guard and the r0 condition keep the rest of the signature well-formed.
+            if (InfinityNorm(z) < _param.Gamma1 - _param.Beta ||
+                !IsRepresentable(z) ||
+                InfinityNorm(r0) >= _param.Gamma2 - _param.Beta)
+            {
+                z = null;
+                h = null;
+            }
+            else
+            {
+                var ct0 = PairwiseMultiply(cHat, t0Hat).Select(NTTInverse).ToArray();
+                var negatedCt0 = NegateMatrix(ct0);
+                var wMinusCs2PlusCt0 = MatrixAdd(MatrixSubtract(w, cs2), ct0);
+
+                h = new int[ct0.Length][];
+                var sumH = 0;
+
+                for (var i = 0; i < ct0.Length; i++)
+                {
+                    h[i] = new int[ct0[i].Length];
+                    for (var j = 0; j < ct0[i].Length; j++)
+                    {
+                        if (MakeHint(negatedCt0[i][j], wMinusCs2PlusCt0[i][j]))
+                        {
+                            h[i][j] = 1;
+                            sumH++;
+                        }
+                    }
+                }
+
+                if (InfinityNorm(ct0) >= _param.Gamma2 || sumH > _param.Omega)
+                {
+                    z = null;
+                    h = null;
+                }
+            }
+
+            kappa += _param.L;
+
+        } while (z == null && h == null);
+
+        return SigEncode(BytesToBits(cTilde), z, h);
+    }
+
+    /// <summary>
+    /// SigEncode packs each z coefficient as Gamma1 - value into 1 + bitlen(Gamma1 - 1) bits, which
+    /// covers exactly [-(Gamma1 - 1), Gamma1]. With the ||z|| rejection disabled a coefficient can
+    /// land outside that range and would not survive an encode/decode round trip.
+    /// </summary>
+    private bool IsRepresentable(int[][] z)
+    {
+        // Coefficients are centered the same way SigEncode does before it packs them
+        return z.All(polynomial => polynomial.All(coefficient =>
+            coefficient.PlusMinusMod(_param.Q) >= -(_param.Gamma1 - 1) &&
+            coefficient.PlusMinusMod(_param.Q) <= _param.Gamma1));
+    }
+}

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.Dilithium.Tests/DilithiumLargeZNormTests.cs
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.Dilithium.Tests/DilithiumLargeZNormTests.cs
@@ -1,0 +1,145 @@
+using System.Collections;
+using System.Linq;
+using NIST.CVP.ACVTS.Libraries.Crypto.Common.Hash.ShaWrapper;
+using NIST.CVP.ACVTS.Libraries.Crypto.Common.PQC.Dilithium;
+using NIST.CVP.ACVTS.Libraries.Crypto.SHA.NativeFastSha;
+using NIST.CVP.ACVTS.Libraries.Math;
+using NIST.CVP.ACVTS.Tests.Core.TestCategoryAttributes;
+using NUnit.Framework;
+
+namespace NIST.CVP.ACVTS.Libraries.Crypto.Dilithium.Tests;
+
+[TestFixture]
+[FastCryptoTest]
+public class DilithiumLargeZNormTests
+{
+    private static readonly BitString Seed = new BitString("0000000000000000000000000000000000000000000000000000000000000000");
+    private static readonly BitString Message = new BitString("0123456789ABCDEF");
+
+    /// <summary>
+    /// The signature has to be rejected by a conformant verifier, and the reason has to be the ||z||
+    /// bound rather than anything else, so the decoded ||z|| must be at or above gamma1 - beta.
+    /// </summary>
+    [Test]
+    [TestCase(DilithiumParameterSet.ML_DSA_44)]
+    [TestCase(DilithiumParameterSet.ML_DSA_65)]
+    [TestCase(DilithiumParameterSet.ML_DSA_87)]
+    public void ShouldProduceSignatureWithZNormOutOfBound(DilithiumParameterSet parameterSet)
+    {
+        var param = new DilithiumParameters(parameterSet);
+        var dilithium = new DilithiumExposed(parameterSet, new NativeShaFactory());
+        var largeZNorm = new DilithiumLargeZNorm(parameterSet, new NativeShaFactory());
+
+        var key = dilithium.GenerateKey(new BitArray(Seed.ToBytes(true)));
+        var signature = largeZNorm.Sign(key.sk, Message.ToBytes(), new byte[32]);
+
+        var (_, z, _) = dilithium.SigDecode(signature);
+
+        Assert.That(signature.Length, Is.EqualTo(param.SignatureLength), "signature length");
+        Assert.That(dilithium.InfinityNorm(z), Is.GreaterThanOrEqualTo(param.Gamma1 - param.Beta), "||z||");
+        Assert.That(dilithium.Verify(key.pk, Message.ToBytes(), signature), Is.False, "verify");
+    }
+
+    /// <summary>
+    /// The ||z|| bound has to be the only reason the signature fails. Everything else about the
+    /// signature stays well formed, so re-deriving the commitment hash the way Verify does has to
+    /// reproduce the c_tilde carried in the signature. A mutated signature would fail here, which is
+    /// what makes this disposition different from ModifyZ.
+    /// </summary>
+    [Test]
+    [TestCase(DilithiumParameterSet.ML_DSA_44)]
+    [TestCase(DilithiumParameterSet.ML_DSA_65)]
+    [TestCase(DilithiumParameterSet.ML_DSA_87)]
+    public void ShouldProduceSignatureWhereOnlyZNormCheckFails(DilithiumParameterSet parameterSet)
+    {
+        var param = new DilithiumParameters(parameterSet);
+        var dilithium = new DilithiumExposed(parameterSet, new NativeShaFactory());
+        var largeZNorm = new DilithiumLargeZNorm(parameterSet, new NativeShaFactory());
+
+        var key = dilithium.GenerateKey(new BitArray(Seed.ToBytes(true)));
+        var signature = largeZNorm.Sign(key.sk, Message.ToBytes(), new byte[32]);
+
+        var (cTilde, z, h) = dilithium.SigDecode(signature);
+
+        // h decodes, so the hint block is well formed
+        Assert.That(h, Is.Not.Null, "hint decode");
+
+        // Recompute c_tilde' the way FIPS 204 Algorithm 8 does
+        var (rho, t1) = dilithium.PkDecode(key.pk);
+        var aHat = dilithium.ExpandA(rho);
+        var c = dilithium.SampleInBall(dilithium.BitsToBytes(cTilde));
+        var cHat = dilithium.NTT(c);
+        var zHat = z.Select(dilithium.NTT).ToArray();
+
+        var t1Shifted = t1.Select(polynomial => polynomial.Select(coefficient => coefficient << param.D).ToArray()).ToArray();
+        var azMinusCt1 = dilithium.MatrixSubtractExposed(
+            dilithium.MatrixMultiplyExposed(aHat, zHat),
+            dilithium.PairwiseMultiplyExposed(cHat, t1Shifted.Select(dilithium.NTT).ToArray()));
+        var wApprox = azMinusCt1.Select(dilithium.NTTInverse).ToArray();
+
+        var w1 = new int[param.K][];
+        for (var i = 0; i < param.K; i++)
+        {
+            w1[i] = new int[wApprox[i].Length];
+            for (var j = 0; j < wApprox[i].Length; j++)
+            {
+                w1[i][j] = dilithium.UseHint(h[i][j] == 1, wApprox[i][j]);
+            }
+        }
+
+        var mu = new byte[64];
+        var tr = dilithium.SkDecode(key.sk).tr;
+        var shake = new NativeShaFactory().GetShakeInstance(new HashFunction(ModeValues.SHAKE, DigestSizes.d256));
+        shake.Init();
+        shake.Update(dilithium.BitsToBytes(tr), tr.Length);
+        shake.Update(Message.ToBytes(), Message.ToBytes().Length * 8);
+        shake.Final(mu, 512);
+
+        var cTildePrime = new byte[(2 * param.Lambda) / 8];
+        var w1Encode = dilithium.W1Encode(w1);
+        shake.Init();
+        shake.Update(mu, mu.Length * 8);
+        shake.Update(dilithium.BitsToBytes(w1Encode), w1Encode.Length);
+        shake.Final(cTildePrime, 2 * param.Lambda);
+
+        Assert.That(new BitString(cTildePrime).ToHex(), Is.EqualTo(new BitString(dilithium.BitsToBytes(cTilde)).ToHex()),
+            "commitment hash still matches, so ||z|| is the only failing check");
+    }
+
+    /// <summary>
+    /// SigEncode packs z into [-(gamma1 - 1), gamma1]. With the rejection inverted a candidate
+    /// coefficient can exceed that, so the signer skips those; the signature must round trip.
+    /// </summary>
+    [Test]
+    [TestCase(DilithiumParameterSet.ML_DSA_44)]
+    [TestCase(DilithiumParameterSet.ML_DSA_65)]
+    [TestCase(DilithiumParameterSet.ML_DSA_87)]
+    public void ShouldProduceEncodableSignature(DilithiumParameterSet parameterSet)
+    {
+        var dilithium = new DilithiumExposed(parameterSet, new NativeShaFactory());
+        var largeZNorm = new DilithiumLargeZNorm(parameterSet, new NativeShaFactory());
+
+        var key = dilithium.GenerateKey(new BitArray(Seed.ToBytes(true)));
+        var signature = largeZNorm.Sign(key.sk, Message.ToBytes(), new byte[32]);
+
+        var (cTilde, z, h) = dilithium.SigDecode(signature);
+        var reEncoded = dilithium.SigEncode(cTilde, z, h);
+
+        Assert.That(new BitString(reEncoded).ToHex(), Is.EqualTo(new BitString(signature).ToHex()), "round trip");
+    }
+
+    /// <summary>
+    /// The polynomial arithmetic needed to re-derive the commitment hash is protected on Dilithium.
+    /// Exposing it here keeps the test using the implementation under test rather than a second copy.
+    /// </summary>
+    private class DilithiumExposed : Dilithium
+    {
+        public DilithiumExposed(DilithiumParameterSet param, IShaFactory shaFactory) : base(param, shaFactory) { }
+
+        public int[][] MatrixMultiplyExposed(int[][][] a, int[][] b) => MatrixMultiply(a, b);
+
+        public int[][] PairwiseMultiplyExposed(int[] a, int[][] b) => PairwiseMultiply(a, b);
+
+        public int[][] MatrixSubtractExposed(int[][] a, int[][] b) => MatrixSubtract(a, b);
+    }
+}

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-DSA/FIPS204/v1_0/SigVer/TestCaseExpectations/SignatureExpectationProvider.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-DSA/FIPS204/v1_0/SigVer/TestCaseExpectations/SignatureExpectationProvider.cs
@@ -15,7 +15,8 @@ public class SignatureExpectationProvider : TestCaseExpectationProviderBase<MLDS
             { MLDSASignatureDisposition.ModifyMessage, 3 },
             { MLDSASignatureDisposition.ModifySignature, 3 },
             { MLDSASignatureDisposition.ModifyHint, 3 },
-            { MLDSASignatureDisposition.ModifyZ, 3 }
+            { MLDSASignatureDisposition.ModifyZ, 3 },
+            { MLDSASignatureDisposition.LargeZNorm, 3 }
         };
 
         LoadExpectationReasons(expectationReasons);

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-DSA/FIPS204/v1_0/SigVer/TestCaseGenerator.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-DSA/FIPS204/v1_0/SigVer/TestCaseGenerator.cs
@@ -20,8 +20,8 @@ public class TestCaseGenerator : ITestCaseGeneratorWithPrep<TestGroup, TestCase>
     private ShuffleQueue<int> _contextLengths;
     private ShuffleQueue<HashFunctions> _hashFunctions;
     
-    // Set up to use 3 of each possible disposition, 15 is a placeholder
-    public int NumberOfTestCasesToGenerate { get; private set; } = 15;
+    // Set up to use 3 of each possible disposition, 18 is a placeholder
+    public int NumberOfTestCasesToGenerate { get; private set; } = 18;
 
     public TestCaseGenerator(IOracle oracle)
     {
@@ -30,7 +30,7 @@ public class TestCaseGenerator : ITestCaseGeneratorWithPrep<TestGroup, TestCase>
     
     public GenerateResponse PrepareGenerator(TestGroup group, bool isSample)
     {
-        NumberOfTestCasesToGenerate = group.TestCaseExpectationProvider.ExpectationCount;   // 15
+        NumberOfTestCasesToGenerate = group.TestCaseExpectationProvider.ExpectationCount;   // 18
 
         // Add min, max and fill rest with random values
         var messageLengthList = new List<int>

--- a/gen-val/src/oracle/src/NIST.CVP.ACVTS.Libraries.Oracle.Abstractions/DispositionTypes/MLDSASignatureDisposition.cs
+++ b/gen-val/src/oracle/src/NIST.CVP.ACVTS.Libraries.Oracle.Abstractions/DispositionTypes/MLDSASignatureDisposition.cs
@@ -4,7 +4,7 @@ namespace NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.DispositionTypes;
 
 public enum MLDSASignatureDisposition
 {
-    // TODO add HintCheck, LargeZNorm, CommitmentHash (covered by modify signature and modify message)
+    // TODO add HintCheck, CommitmentHash (covered by modify signature and modify message)
     
     [EnumMember(Value = "valid signature and message - signature should verify successfully")]
     None,
@@ -19,5 +19,8 @@ public enum MLDSASignatureDisposition
     ModifyHint,
     
     [EnumMember(Value = "modified signature - z")]
-    ModifyZ
+    ModifyZ,
+    
+    [EnumMember(Value = "invalid signature - z norm too large")]
+    LargeZNorm
 }

--- a/gen-val/src/orleans/src/NIST.CVP.ACVTS.Libraries.Orleans.Grains/Pqc/OracleObserverMLDSAVerifyCaseGrain.cs
+++ b/gen-val/src/orleans/src/NIST.CVP.ACVTS.Libraries.Orleans.Grains/Pqc/OracleObserverMLDSAVerifyCaseGrain.cs
@@ -113,6 +113,25 @@ public class OracleObserverMLDSAVerifyCaseGrain : ObservableOracleGrainBase<Veri
                 var zBit = (mldsaParameters.Lambda * 2) + 1;
                 result.Signature.Bits.Set(zBit, !result.Signature.Bits.Get(zBit));
                 break;
+
+            case MLDSASignatureDisposition.LargeZNorm:
+                // A mutation cannot exercise the ||z|| bound: any change to z also changes w' and the
+                // commitment hash rejects the signature first. Re-sign with a signer whose rejection
+                // step keeps ||z|| >= gamma1 - beta candidates instead, so the ||z|| check in
+                // FIPS 204 Algorithm 8 is the only condition that rejects the signature.
+                var largeZNorm = new DilithiumLargeZNorm(_param.ParameterSet, _shaFactory);
+                var largeZNormSignature = (_param.SignatureInterface, _param.PreHash, _param.ExternalMu) switch
+                {
+                    (SignatureInterface.Internal, _, true) => largeZNorm.SignExternalMu(_param.PrivateKey.ToBytes(), mu.ToBytes(), BitString.Zeroes(256).ToBytes()),
+                    (SignatureInterface.Internal, _, false) => largeZNorm.Sign(_param.PrivateKey.ToBytes(), message.ToBytes(), BitString.Zeroes(256).ToBytes()),
+
+                    (SignatureInterface.External, PreHash.Pure, _) => largeZNorm.ExternalSign(_param.PrivateKey.ToBytes(), message.ToBytes(), _param.Deterministic, context.ToBytes()),
+                    (SignatureInterface.External, PreHash.PreHash, _) => largeZNorm.ExternalPreHashSign(_param.PrivateKey.ToBytes(), message.ToBytes(), _param.Deterministic, context.ToBytes(), ShaAttributes.GetHashFunctionFromEnum(_param.HashFunction)),
+
+                    (_, _, _) => throw new ArgumentException("Invalid combination of parameters for ML-DSA")
+                };
+                result.Signature = new BitString(largeZNormSignature);
+                break;
         }
         
         await Notify(new VerifyResult<MLDSASignatureResult>


### PR DESCRIPTION
Implements the LargeZNorm item from the TODO discussed in #462.

## Why a mutation cannot cover this

The existing "modified signature - z" disposition mutates an existing signature. Any change to z also changes w', so the commitment hash rejects the signature even in a verifier that omits the ||z|| check entirely. Across the current 180-case sigVer file, removing the ||z||inf < gamma1 - beta check from a verifier changes zero outcomes. The check needs a signature that is valid everywhere except the z bound, and only the signer can produce one.

## What this does

- `DilithiumLargeZNorm` derives from `Dilithium` and overrides `Sign` with the z half of the rejection step inverted: it keeps only candidates where ||z||inf >= gamma1 - beta, while the r0, ct0 and hint conditions stay in place. The signature remains internally consistent, so the commitment hash comparison in Verify passes and the ||z|| bound is the only condition that rejects it.
- Candidates with a coefficient outside [-(gamma1 - 1), gamma1] are skipped, since SigEncode cannot represent them; the emitted signature round-trips through SigEncode/SigDecode exactly.
- About 40 percent of candidates land out of bound (as estimated in the issue thread), so the loop terminates after a few iterations; measured convergence is 5 to 6 iterations per signature.
- New disposition `invalid signature - z norm too large` wired through `MLDSASignatureDisposition`, the sigVer expectation provider (three occurrences per group, matching the existing reasons), and the sigVer grain across all four interface paths (internal, externalMu, external pure, external pre-hash).
- One change to existing code: `Dilithium.SignExternalMu` is marked `virtual` so the derived signer covers the externalMu path. `Sign` was already overridable.

## Verification

- New unit tests, per parameter set: the emitted signature has ||z||inf >= gamma1 - beta and fails Verify; re-deriving the commitment hash the way Algorithm 8 does reproduces the c_tilde carried in the signature, so the z bound is the only failing check; and the signature round-trips through SigEncode. 9 tests, all passing.
- Existing Dilithium test suite: 209 passing, 0 failures.
- ML-DSA sigVer generation tests: 26 passing, 0 failures.
- Cross-checked against an independent Python implementation of FIPS 204 written from the standard text: 12 signatures produced by this signer (all three parameter sets) are rejected by a conformant verifier with the z bound as the only failing condition, and are accepted by the same verifier with the z check removed. That last part is the property the disposition exists to test, and it is the acceptance test proposed in #462.

The sample json files are not regenerated here, per the note in #462 that the corner-case database and sample generation live on the internal side.
