### PR TITLE
Corrects LmsPrivateKey dropping the last precomputed tree node

### DIFF
--- a/gen-val/src/crypto/src/NIST.CVP.ACVTS.Libraries.Crypto/LMS/Native/Keys/LmsPrivateKey.cs
+++ b/gen-val/src/crypto/src/NIST.CVP.ACVTS.Libraries.Crypto/LMS/Native/Keys/LmsPrivateKey.cs
@@ -55,7 +55,7 @@ namespace NIST.CVP.ACVTS.Libraries.Crypto.LMS.Native.Keys
                 {
                     // Just tree values, hashes[0] is T[1]
                     T = new byte[hashes.Length+1][];
-                    for (var j = 1; j < hashes.Length; j++)
+                    for (var j = 1; j <= hashes.Length; j++)
                     {
                         T[j] = hashes[j-1];
                     }

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.LMS.Tests/Native/Keys/LmsPrivateKeyTests.cs
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.LMS.Tests/Native/Keys/LmsPrivateKeyTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Linq;
+using NIST.CVP.ACVTS.Libraries.Crypto.Common.Asymmetric.LMS.Native.Enums;
+using NIST.CVP.ACVTS.Libraries.Crypto.Common.Asymmetric.LMS.Native.Helpers;
+using NIST.CVP.ACVTS.Libraries.Crypto.LMS.Native.Keys;
+using NIST.CVP.ACVTS.Tests.Core.TestCategoryAttributes;
+using NUnit.Framework;
+
+namespace NIST.CVP.ACVTS.Libraries.Crypto.LMS.Tests.Native.Keys
+{
+    [TestFixture, FastCryptoTest]
+    public class LmsPrivateKeyTests
+    {
+        private static readonly LmsAttribute _lmsAttribute = AttributesHelper.GetLmsAttribute(LmsMode.LMS_SHA256_M24_H5);
+        private static readonly LmOtsAttribute _lmOtsAttribute = AttributesHelper.GetLmOtsAttribute(LmOtsMode.LMOTS_SHA256_N24_W1);
+
+        [Test]
+        public void WhenGivenEitherPrecomputedTreeShape_ShouldExposeIdenticalNodes()
+        {
+            const int x = 2;
+            var nodeCount = (2 << x) - 1;
+            var nodes = Nodes(nodeCount);
+
+            // compact shape: values only, hashes[0] is T[1]
+            var compact = KeyWithTree(x, nodes);
+
+            // one-indexed shape: slot 0 unused
+            var oneIndexed = KeyWithTree(x, new byte[][] { Array.Empty<byte>() }.Concat(nodes).ToArray());
+
+            Assert.Multiple(() =>
+            {
+                for (var r = 1; r <= nodeCount; r++)
+                {
+                    Assert.That(compact.HasPrecomputedHash(r), Is.True, $"compact node {r} present");
+                    Assert.That(oneIndexed.HasPrecomputedHash(r), Is.True, $"one-indexed node {r} present");
+                    Assert.That(compact.GetTreeNodeAtIndex(r), Is.EqualTo(oneIndexed.GetTreeNodeAtIndex(r)),
+                        $"node {r} equal across shapes");
+                }
+
+                Assert.That(compact.HasPrecomputedHash(nodeCount + 1), Is.False, "beyond stored range");
+            });
+        }
+
+        [Test]
+        public void WhenGivenIncompleteTree_ShouldThrow()
+        {
+            Assert.Throws<ArgumentException>(() => KeyWithTree(2, Nodes(3)));
+        }
+
+        private static byte[][] Nodes(int count)
+        {
+            // distinct, recognizable node values
+            return Enumerable.Range(1, count)
+                .Select(i => Enumerable.Repeat((byte)i, 24).ToArray())
+                .ToArray();
+        }
+
+        private static LmsPrivateKey KeyWithTree(int x, byte[][] hashes)
+        {
+            return new LmsPrivateKey(_lmsAttribute, _lmOtsAttribute, new byte[16], new byte[24], 0, x, hashes);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`LmsPrivateKey` accepts two shapes for its precomputed tree: a one-indexed `2 << X` array with slot 0 unused, and a compact `(2 << X) - 1` array of values only. The compact branch's copy loop stopped one element early (`j < hashes.Length` over a target sized `hashes.Length + 1`), so the final supplied node — the right-most node of the deepest stored layer — was silently dropped and `T[hashes.Length]` stayed null.

The result is not incorrect signatures: `Lms.Sign`'s `CalculateT` falls back to recomputing the subtree below any node `HasPrecomputedHash` misses, so signing output is unchanged. The cost is performance — every authentication path that touches the dropped node recomputes its subtree down to the leaves through OTS key generation, which for the top `X` layers of an H20/H25 tree is exactly the work the precomputed tree exists to avoid. The `PrecomputedTrees` test fixtures parse into the compact shape, so they take this fallback today.

This corrects the loop bound to copy the final node and adds `LmsPrivateKeyTests` pinning both constructor shapes to expose identical stored nodes (the equivalence test fails on the previous code at the last node), plus the incomplete-tree rejection path.

## Verification

- `NIST.CVP.ACVTS.Libraries.Crypto.LMS.Tests` FastCryptoTest suite: 121/121 passing, confirming stored and recomputed values agree for the existing fixtures

Noticed while modeling the XMSS private key on this class for #466.
