### PR TITLE
Cover every pre-hash function with a valid ML-DSA/SLH-DSA sigVer case

### DIFF
--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-DSA/FIPS204/v1_0/SigVer/TestCaseExpectations/SignatureExpectationProvider.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-DSA/FIPS204/v1_0/SigVer/TestCaseExpectations/SignatureExpectationProvider.cs
@@ -7,11 +7,21 @@ namespace NIST.CVP.ACVTS.Libraries.Generation.ML_DSA.FIPS204.v1_0.SigVer.TestCas
 
 public class SignatureExpectationProvider : TestCaseExpectationProviderBase<MLDSASignatureDisposition>
 {
-    public SignatureExpectationProvider()
+    public SignatureExpectationProvider() : this(3)
+    {
+    }
+
+    /// <summary>
+    /// validCount controls how many valid (None) cases the group carries. Pre-hash groups pass the
+    /// number of registered hash functions so every one of them can be paired with a valid case; only
+    /// a valid case can test that the verifier used the right pre-hash OID and digest, since a negative
+    /// case is expected to fail whichever pre-hash function it names.
+    /// </summary>
+    public SignatureExpectationProvider(int validCount)
     {
         var expectationReasons = new List<MLDSASignatureDisposition>
         {
-            { MLDSASignatureDisposition.None, 3 },
+            { MLDSASignatureDisposition.None, validCount },
             { MLDSASignatureDisposition.ModifyMessage, 3 },
             { MLDSASignatureDisposition.ModifySignature, 3 },
             { MLDSASignatureDisposition.ModifyHint, 3 },

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-DSA/FIPS204/v1_0/SigVer/TestCaseGenerator.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-DSA/FIPS204/v1_0/SigVer/TestCaseGenerator.cs
@@ -8,6 +8,7 @@ using NIST.CVP.ACVTS.Libraries.Generation.Core;
 using NIST.CVP.ACVTS.Libraries.Generation.Core.Async;
 using NIST.CVP.ACVTS.Libraries.Math;
 using NIST.CVP.ACVTS.Libraries.Oracle.Abstractions;
+using NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.DispositionTypes;
 using NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.ParameterTypes.ML_DSA;
 using NLog;
 
@@ -19,6 +20,7 @@ public class TestCaseGenerator : ITestCaseGeneratorWithPrep<TestGroup, TestCase>
     private ShuffleQueue<int> _messageLengths;
     private ShuffleQueue<int> _contextLengths;
     private ShuffleQueue<HashFunctions> _hashFunctions;
+    private ShuffleQueue<HashFunctions> _validHashFunctions;
     
     // Set up to use 3 of each possible disposition, 15 is a placeholder
     public int NumberOfTestCasesToGenerate { get; private set; } = 15;
@@ -57,7 +59,10 @@ public class TestCaseGenerator : ITestCaseGeneratorWithPrep<TestGroup, TestCase>
             if (group.PreHash == PreHash.PreHash)
             {
                 _hashFunctions = new ShuffleQueue<HashFunctions>(group.HashFunctions.ToList());
-                
+                // Valid cases draw from their own queue so each registered hash function is paired with a
+                // valid case; the expectation provider supplies one None per hash function for these groups.
+                _validHashFunctions = new ShuffleQueue<HashFunctions>(group.HashFunctions.ToList());
+
                 // It is not a requirement but a recommendation to filter by hash functions strong enough for the parameter set, we want to test all valid possibilities though not just the recommended ones
                 // var lambda = new DilithiumParameters(group.ParameterSet).Lambda;
                 //
@@ -75,7 +80,19 @@ public class TestCaseGenerator : ITestCaseGeneratorWithPrep<TestGroup, TestCase>
         {
             var keyParam = new MLDSAKeyGenParameters { ParameterSet = group.ParameterSet };
             var keyResult = await _oracle.GetMLDSAKeyCaseAsync(keyParam);
-            
+
+            var disposition = group.TestCaseExpectationProvider.GetRandomReason();
+
+            // On pre-hash groups, valid cases pull from the coverage queue so every registered hash
+            // function gets a valid case; negative cases can use any function.
+            var hashFunction = HashFunctions.None;
+            if (group.PreHash == PreHash.PreHash)
+            {
+                hashFunction = disposition == MLDSASignatureDisposition.None
+                    ? _validHashFunctions.Pop()
+                    : _hashFunctions.Pop();
+            }
+
             var param = new MLDSASignatureParameters
             {
                 ParameterSet = group.ParameterSet,
@@ -85,9 +102,9 @@ public class TestCaseGenerator : ITestCaseGeneratorWithPrep<TestGroup, TestCase>
                 ExternalMu = group.ExternalMu,
                 SignatureInterface = group.SignatureInterface,
                 PrivateKey = keyResult.PrivateKey,
-                HashFunction = group.PreHash == PreHash.PreHash ? _hashFunctions.Pop() : HashFunctions.None,    // Only used on PreHash
+                HashFunction = hashFunction,            // Only used on PreHash
                 ContextLength = group.SignatureInterface == SignatureInterface.External ? _contextLengths.Pop() : 0, // Only used on External interface
-                Disposition = group.TestCaseExpectationProvider.GetRandomReason()
+                Disposition = disposition
             };
             
             var result = await _oracle.GetMLDSAVerifyResultAsync(param);

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-DSA/FIPS204/v1_0/SigVer/TestGroupGenerator.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-DSA/FIPS204/v1_0/SigVer/TestGroupGenerator.cs
@@ -54,7 +54,11 @@ public class TestGroupGenerator : ITestGroupGeneratorAsync<Parameters, TestGroup
                                     HashFunctions = capability.HashAlgs,
                                     MessageLength = capability.MessageLength,
                                     ContextLength = capability.ContextLength,
-                                    TestCaseExpectationProvider = new SignatureExpectationProvider()
+                                    // Pre-hash groups need one valid case per registered hash function so
+                                    // each function's OID and digest binding is actually tested.
+                                    TestCaseExpectationProvider = preHash == PreHash.PreHash
+                                        ? new SignatureExpectationProvider(capability.HashAlgs.Length)
+                                        : new SignatureExpectationProvider()
                                 };
 
                                 testGroups.Add(testGroup);

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/SLH-DSA/FIPS205/SigVer/TestCaseExpectations/SignatureExpectationProvider.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/SLH-DSA/FIPS205/SigVer/TestCaseExpectations/SignatureExpectationProvider.cs
@@ -7,11 +7,21 @@ namespace NIST.CVP.ACVTS.Libraries.Generation.SLH_DSA.FIPS205.SigVer.TestCaseExp
 
 public class SignatureExpectationProvider : TestCaseExpectationProviderBase<SLHDSASignatureDisposition>
 {
-    public SignatureExpectationProvider()
+    public SignatureExpectationProvider() : this(2)
+    {
+    }
+
+    /// <summary>
+    /// validCount controls how many valid (None) cases the group carries. Pre-hash groups pass the
+    /// number of registered hash functions so every one of them can be paired with a valid case; only
+    /// a valid case can test that the verifier used the right pre-hash OID and digest, since a negative
+    /// case is expected to fail whichever pre-hash function it names.
+    /// </summary>
+    public SignatureExpectationProvider(int validCount)
     {
         var expectationReasons = new List<SLHDSASignatureDisposition>
         {
-            { SLHDSASignatureDisposition.None, 2 },
+            { SLHDSASignatureDisposition.None, validCount },
             { SLHDSASignatureDisposition.ModifyMessage, 2 },
             { SLHDSASignatureDisposition.ModifySignatureR, 2 },
             { SLHDSASignatureDisposition.ModifySignatureSigFors, 2 },

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/SLH-DSA/FIPS205/SigVer/TestCaseGenerator.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/SLH-DSA/FIPS205/SigVer/TestCaseGenerator.cs
@@ -8,6 +8,7 @@ using NIST.CVP.ACVTS.Libraries.Generation.Core;
 using NIST.CVP.ACVTS.Libraries.Generation.Core.Async;
 using NIST.CVP.ACVTS.Libraries.Math;
 using NIST.CVP.ACVTS.Libraries.Oracle.Abstractions;
+using NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.DispositionTypes;
 using NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.ParameterTypes.SLH_DSA;
 using NLog;
 
@@ -19,6 +20,7 @@ public class TestCaseGenerator : ITestCaseGeneratorWithPrep<TestGroup, TestCase>
     private ShuffleQueue<int> _messageLengths;
     private ShuffleQueue<int> _contextLengths;
     private ShuffleQueue<HashFunctions> _hashFunctions;
+    private ShuffleQueue<HashFunctions> _validHashFunctions;
     
     // Set up to use each of the possible dispositions 2X, placeholder to be calculated later
     public int NumberOfTestCasesToGenerate { get; private set; } = 14;
@@ -57,6 +59,9 @@ public class TestCaseGenerator : ITestCaseGeneratorWithPrep<TestGroup, TestCase>
             if (group.PreHash == PreHash.PreHash)
             {
                 _hashFunctions = new ShuffleQueue<HashFunctions>(group.HashFunctions.ToList());
+                // Valid cases draw from their own queue so each registered hash function is paired with a
+                // valid case; the expectation provider supplies one None per hash function for these groups.
+                _validHashFunctions = new ShuffleQueue<HashFunctions>(group.HashFunctions.ToList());
                 
                 // It is not a requirement but a recommendation to filter by hash functions strong enough for the parameter set, we want to test all valid possibilities though not just the recommended ones
             }
@@ -71,17 +76,29 @@ public class TestCaseGenerator : ITestCaseGeneratorWithPrep<TestGroup, TestCase>
         {
             var keyParam = new SLHDSAKeyGenParameters { SlhdsaParameterSet = group.ParameterSet };
             var keyResult = await _oracle.GetSLHDSAKeyCaseAsync(keyParam);
-            
+
+            var disposition = group.TestCaseExpectationProvider.GetRandomReason();
+
+            // On pre-hash groups, valid cases pull from the coverage queue so every registered hash
+            // function gets a valid case; negative cases can use any function.
+            var hashFunction = HashFunctions.None;
+            if (group.PreHash == PreHash.PreHash)
+            {
+                hashFunction = disposition == SLHDSASignatureDisposition.None
+                    ? _validHashFunctions.Pop()
+                    : _hashFunctions.Pop();
+            }
+
             var param = new SLHDSASignatureParameters
             {
                 SlhdsaParameterSet = group.ParameterSet,
                 Deterministic = false,
                 MessageLength = _messageLengths.Pop(),
-                Disposition = group.TestCaseExpectationProvider.GetRandomReason(),
+                Disposition = disposition,
                 PreHash = group.PreHash,
                 SignatureInterface = group.SignatureInterface,
                 PrivateKey = keyResult.PrivateKey,
-                HashFunction = group.PreHash == PreHash.PreHash ? _hashFunctions.Pop() : HashFunctions.None, // Only used on PreHash
+                HashFunction = hashFunction, // Only used on PreHash
                 ContextLength = group.SignatureInterface == SignatureInterface.External ? _contextLengths.Pop() : 0 // Only used on External interface
             };
             

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/SLH-DSA/FIPS205/SigVer/TestGroupGenerator.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/SLH-DSA/FIPS205/SigVer/TestGroupGenerator.cs
@@ -49,7 +49,11 @@ public class TestGroupGenerator : ITestGroupGeneratorAsync<Parameters, TestGroup
                                     PreHash = preHash,
                                     HashFunctions = capability.HashAlgs,
                                     ContextLength = capability.ContextLength,
-                                    TestCaseExpectationProvider = new SignatureExpectationProvider()
+                                    // Pre-hash groups need one valid case per registered hash function so
+                                    // each function's OID and digest binding is actually tested.
+                                    TestCaseExpectationProvider = preHash == PreHash.PreHash
+                                        ? new SignatureExpectationProvider(capability.HashAlgs.Length)
+                                        : new SignatureExpectationProvider()
                                 };
                                 
                                 testGroups.Add(extTestGroup);

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Tests/ML-DSA/FIPS204/v1_0/SigVer/PreHashCoverageTests.cs
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Tests/ML-DSA/FIPS204/v1_0/SigVer/PreHashCoverageTests.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Linq;
+using NIST.CVP.ACVTS.Libraries.Crypto.Common.Hash.ShaWrapper.Enums;
+using NIST.CVP.ACVTS.Libraries.Crypto.Common.PQC.Enums;
+using NIST.CVP.ACVTS.Libraries.Generation.ML_DSA.FIPS204.v1_0.SigVer;
+using NIST.CVP.ACVTS.Libraries.Generation.ML_DSA.FIPS204.v1_0.SigVer.TestCaseExpectations;
+using NIST.CVP.ACVTS.Libraries.Math;
+using NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.DispositionTypes;
+using NIST.CVP.ACVTS.Tests.Core.TestCategoryAttributes;
+using NUnit.Framework;
+
+namespace NIST.CVP.ACVTS.Libraries.Generation.Tests.ML_DSA.FIPS204.v1_0.SigVer;
+
+/// <summary>
+/// A negative pre-hash case cannot test which pre-hash function the verifier used, since it is expected
+/// to fail whichever function it names. Only a valid case can. These tests show that a pre-hash group
+/// now carries one valid case per registered hash function, and that pairing valid cases with the
+/// coverage queue gives every function a valid case.
+/// </summary>
+[TestFixture, UnitTest]
+public class PreHashCoverageTests
+{
+    private static readonly HashFunctions[] AllHashFunctions =
+    {
+        HashFunctions.Sha2_d224, HashFunctions.Sha2_d256, HashFunctions.Sha2_d384, HashFunctions.Sha2_d512,
+        HashFunctions.Sha2_d512t224, HashFunctions.Sha2_d512t256,
+        HashFunctions.Sha3_d224, HashFunctions.Sha3_d256, HashFunctions.Sha3_d384, HashFunctions.Sha3_d512,
+        HashFunctions.Shake_d128, HashFunctions.Shake_d256
+    };
+
+    [Test]
+    public void PreHashProviderHasOneValidCasePerHashFunction()
+    {
+        var provider = new SignatureExpectationProvider(AllHashFunctions.Length);
+
+        var count = provider.ExpectationCount;
+        var reasons = new List<MLDSASignatureDisposition>();
+        for (var i = 0; i < count; i++)
+        {
+            reasons.Add(provider.GetRandomReason());
+        }
+
+        var valid = reasons.Count(r => r == MLDSASignatureDisposition.None);
+        Assert.That(valid, Is.EqualTo(AllHashFunctions.Length), "one valid case per hash function");
+    }
+
+    [Test]
+    public void ValidCasesPairedWithCoverageQueueCoverEveryHashFunction()
+    {
+        // Reproduces the generator's pairing: the provider gives one None per hash function, and each
+        // None draws from a shuffled queue of all functions, so every function gets a valid case.
+        var provider = new SignatureExpectationProvider(AllHashFunctions.Length);
+        var coverage = new ShuffleQueue<HashFunctions>(AllHashFunctions.ToList());
+
+        var count = provider.ExpectationCount;
+        var covered = new HashSet<HashFunctions>();
+        for (var i = 0; i < count; i++)
+        {
+            if (provider.GetRandomReason() == MLDSASignatureDisposition.None)
+            {
+                covered.Add(coverage.Pop());
+            }
+        }
+
+        Assert.That(covered, Is.EquivalentTo(AllHashFunctions), "every hash function has a valid case");
+    }
+
+    [Test]
+    public void NonPreHashProviderIsUnchanged()
+    {
+        var provider = new SignatureExpectationProvider();
+
+        var count = provider.ExpectationCount;
+        var reasons = new List<MLDSASignatureDisposition>();
+        for (var i = 0; i < count; i++)
+        {
+            reasons.Add(provider.GetRandomReason());
+        }
+
+        Assert.That(reasons.Count, Is.EqualTo(15), "default group is still 15 cases");
+        Assert.That(reasons.Count(r => r == MLDSASignatureDisposition.None), Is.EqualTo(3), "default group has 3 valid cases");
+    }
+}

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Tests/SLH-DSA/FIPS205/SigVer/PreHashCoverageTests.cs
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Tests/SLH-DSA/FIPS205/SigVer/PreHashCoverageTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using NIST.CVP.ACVTS.Libraries.Crypto.Common.Hash.ShaWrapper.Enums;
+using NIST.CVP.ACVTS.Libraries.Generation.SLH_DSA.FIPS205.SigVer.TestCaseExpectations;
+using NIST.CVP.ACVTS.Libraries.Math;
+using NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.DispositionTypes;
+using NIST.CVP.ACVTS.Tests.Core.TestCategoryAttributes;
+using NUnit.Framework;
+
+namespace NIST.CVP.ACVTS.Libraries.Generation.Tests.SLH_DSA.FIPS205.SigVer;
+
+/// <summary>
+/// A negative pre-hash case cannot test which pre-hash function the verifier used, since it is expected
+/// to fail whichever function it names. Only a valid case can. These tests show that a pre-hash group
+/// now carries one valid case per registered hash function, and that pairing valid cases with the
+/// coverage queue gives every function a valid case.
+/// </summary>
+[TestFixture, UnitTest]
+public class PreHashCoverageTests
+{
+    private static readonly HashFunctions[] AllHashFunctions =
+    {
+        HashFunctions.Sha2_d224, HashFunctions.Sha2_d256, HashFunctions.Sha2_d384, HashFunctions.Sha2_d512,
+        HashFunctions.Sha2_d512t224, HashFunctions.Sha2_d512t256,
+        HashFunctions.Sha3_d224, HashFunctions.Sha3_d256, HashFunctions.Sha3_d384, HashFunctions.Sha3_d512,
+        HashFunctions.Shake_d128, HashFunctions.Shake_d256
+    };
+
+    [Test]
+    public void PreHashProviderHasOneValidCasePerHashFunction()
+    {
+        var provider = new SignatureExpectationProvider(AllHashFunctions.Length);
+
+        var count = provider.ExpectationCount;
+        var reasons = new List<SLHDSASignatureDisposition>();
+        for (var i = 0; i < count; i++)
+        {
+            reasons.Add(provider.GetRandomReason());
+        }
+
+        var valid = reasons.Count(r => r == SLHDSASignatureDisposition.None);
+        Assert.That(valid, Is.EqualTo(AllHashFunctions.Length), "one valid case per hash function");
+    }
+
+    [Test]
+    public void ValidCasesPairedWithCoverageQueueCoverEveryHashFunction()
+    {
+        // Reproduces the generator's pairing: the provider gives one None per hash function, and each
+        // None draws from a shuffled queue of all functions, so every function gets a valid case.
+        var provider = new SignatureExpectationProvider(AllHashFunctions.Length);
+        var coverage = new ShuffleQueue<HashFunctions>(AllHashFunctions.ToList());
+
+        var count = provider.ExpectationCount;
+        var covered = new HashSet<HashFunctions>();
+        for (var i = 0; i < count; i++)
+        {
+            if (provider.GetRandomReason() == SLHDSASignatureDisposition.None)
+            {
+                covered.Add(coverage.Pop());
+            }
+        }
+
+        Assert.That(covered, Is.EquivalentTo(AllHashFunctions), "every hash function has a valid case");
+    }
+
+    [Test]
+    public void NonPreHashProviderIsUnchanged()
+    {
+        var provider = new SignatureExpectationProvider();
+
+        var count = provider.ExpectationCount;
+        var reasons = new List<SLHDSASignatureDisposition>();
+        for (var i = 0; i < count; i++)
+        {
+            reasons.Add(provider.GetRandomReason());
+        }
+
+        Assert.That(reasons.Count, Is.EqualTo(14), "default group is still 14 cases");
+        Assert.That(reasons.Count(r => r == SLHDSASignatureDisposition.None), Is.EqualTo(2), "default group has 2 valid cases");
+    }
+}


### PR DESCRIPTION
Fixes #469, following the shape picked there: more None expectations on pre-hash groups, so the full set of registered hash functions is covered and each is used at least once.

## What changed

Both suites get the same three-part change, ML-DSA FIPS204 v1.0 sigVer and SLH-DSA FIPS205 sigVer:

- `SignatureExpectationProvider` gains a constructor that takes a valid case count. The default constructor keeps the old behavior (3 valid for ML-DSA, 2 for SLH-DSA), so nothing else that uses the provider moves.
- `TestGroupGenerator` constructs pre-hash groups with the number of registered hash functions as the valid count. Non pre-hash groups keep the default.
- `TestCaseGenerator` adds a second shuffled queue holding the registered hash functions and pops the disposition first. Valid cases draw their hash function from that queue, so each registered function is paired with exactly one valid case. Negative cases draw from the general queue as before.

A pre-hash group goes from 15 cases (ML-DSA) or 14 (SLH-DSA) to 24: 12 valid, one per registered hash function, plus the existing 12 negatives. Non pre-hash groups are unchanged.

## Why valid cases specifically

A negative pre-hash case cannot show which pre-hash function the verifier used, because the case is expected to fail whichever function it names. Only a valid case can catch a wrong OID in M' or a wrong digest, and today both suites have fewer valid pre-hash cases than registered functions, so several functions never get one. The measurements are in #469.

## Tests

New `PreHashCoverageTests` in both suites: the provider yields one valid case per hash function, the pairing covers all 12, and the default provider is unchanged. All pass, and the full generation test suite passes with the raised counts, 7678 of 7678.

Sample json files are not regenerated here, matching how #464 was handled.

Note on sequencing: the ML-DSA half touches the same `SignatureExpectationProvider` as #464, so whichever merges second needs a small rebase. Happy to do that rebase on this side either way.