### PR TITLE
Add wrong-length key dispositions for ML-KEM key checks

### DIFF
--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.MLKEM.Tests/WrongLengthKeyTests.cs
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.MLKEM.Tests/WrongLengthKeyTests.cs
@@ -1,0 +1,55 @@
+using NIST.CVP.ACVTS.Libraries.Crypto.Common.PQC.MLKEM;
+using NIST.CVP.ACVTS.Libraries.Crypto.SHA.NativeFastSha;
+using NIST.CVP.ACVTS.Libraries.Math;
+using NIST.CVP.ACVTS.Libraries.Math.Helpers;
+using NIST.CVP.ACVTS.Tests.Core.TestCategoryAttributes;
+using NUnit.Framework;
+
+namespace NIST.CVP.ACVTS.Libraries.Crypto.MLKEM.Tests;
+
+[TestFixture]
+[FastCryptoTest]
+public class WrongLengthKeyTests
+{
+    [Test]
+    [TestCase(MLKEMParameterSet.ML_KEM_512)]
+    [TestCase(MLKEMParameterSet.ML_KEM_768)]
+    [TestCase(MLKEMParameterSet.ML_KEM_1024)]
+    public void ShouldFailEncapsulationKeyCheckWhenLengthIsWrong(MLKEMParameterSet mlkemParameterSet)
+    {
+        var rand = new Random800_90();
+
+        var z = rand.GetRandomBitString(256).ToBytes();
+        var d = rand.GetRandomBitString(256).ToBytes();
+
+        var mlkemParameters = new MLKEMParameters(mlkemParameterSet);
+        var mlkem = new MLKEM(mlkemParameters, new NativeShaFactory());
+
+        var goodKey = mlkem.GenerateKey(z, d);
+
+        Assert.That(mlkem.EncapsulationKeyCheck(goodKey.ek), Is.True, "unmodified ek");
+        Assert.That(mlkem.EncapsulationKeyCheck(goodKey.ek[..^1]), Is.False, "ek too short");
+        Assert.That(mlkem.EncapsulationKeyCheck(goodKey.ek.Concatenate(new byte[] { 0xAA })), Is.False, "ek too long");
+    }
+
+    [Test]
+    [TestCase(MLKEMParameterSet.ML_KEM_512)]
+    [TestCase(MLKEMParameterSet.ML_KEM_768)]
+    [TestCase(MLKEMParameterSet.ML_KEM_1024)]
+    public void ShouldFailDecapsulationKeyCheckWhenLengthIsWrong(MLKEMParameterSet mlkemParameterSet)
+    {
+        var rand = new Random800_90();
+
+        var z = rand.GetRandomBitString(256).ToBytes();
+        var d = rand.GetRandomBitString(256).ToBytes();
+
+        var mlkemParameters = new MLKEMParameters(mlkemParameterSet);
+        var mlkem = new MLKEM(mlkemParameters, new NativeShaFactory());
+
+        var goodKey = mlkem.GenerateKey(z, d);
+
+        Assert.That(mlkem.DecapsulationKeyCheck(goodKey.dk), Is.True, "unmodified dk");
+        Assert.That(mlkem.DecapsulationKeyCheck(goodKey.dk[..^1]), Is.False, "dk too short");
+        Assert.That(mlkem.DecapsulationKeyCheck(goodKey.dk.Concatenate(new byte[] { 0xAA })), Is.False, "dk too long");
+    }
+}

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/tr1/EncapDecap/TestCaseExpectations/DecapsulationKeyExpectationProvider.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/tr1/EncapDecap/TestCaseExpectations/DecapsulationKeyExpectationProvider.cs
@@ -12,7 +12,9 @@ public class DecapsulationKeyExpectationProvider : TestCaseExpectationProviderBa
         var expectationReasons = new List<MLKEMDecapsulationKeyDisposition>
         {
             { MLKEMDecapsulationKeyDisposition.None, 5 },
-            { MLKEMDecapsulationKeyDisposition.ModifyH, 5}
+            { MLKEMDecapsulationKeyDisposition.ModifyH, 5},
+            { MLKEMDecapsulationKeyDisposition.TooShort, 5 },
+            { MLKEMDecapsulationKeyDisposition.TooLong, 5 }
         };
         
         LoadExpectationReasons(expectationReasons);

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/tr1/EncapDecap/TestCaseExpectations/EncapsulationKeyExpectationProvider.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/tr1/EncapDecap/TestCaseExpectations/EncapsulationKeyExpectationProvider.cs
@@ -12,7 +12,9 @@ public class EncapsulationKeyExpectationProvider : TestCaseExpectationProviderBa
         var expectationReasons = new List<MLKEMEncapsulationKeyDisposition>
         {
             { MLKEMEncapsulationKeyDisposition.None, 5 },
-            { MLKEMEncapsulationKeyDisposition.ValuesTooLarge, 5 }
+            { MLKEMEncapsulationKeyDisposition.ValuesTooLarge, 5 },
+            { MLKEMEncapsulationKeyDisposition.TooShort, 5 },
+            { MLKEMEncapsulationKeyDisposition.TooLong, 5 }
         };
 
         LoadExpectationReasons(expectationReasons);

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/tr1/EncapDecap/TestCaseGeneratorDecapsulationKeyCheck.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/tr1/EncapDecap/TestCaseGeneratorDecapsulationKeyCheck.cs
@@ -14,7 +14,7 @@ public class TestCaseGeneratorDecapsulationKeyCheck : ITestCaseGeneratorAsync<Te
 {
     private readonly IOracle _oracle;
     
-    public int NumberOfTestCasesToGenerate => 10;
+    public int NumberOfTestCasesToGenerate => 20;
 
     public TestCaseGeneratorDecapsulationKeyCheck(IOracle oracle)
     {

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/tr1/EncapDecap/TestCaseGeneratorEncapsulationKeyCheck.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/tr1/EncapDecap/TestCaseGeneratorEncapsulationKeyCheck.cs
@@ -14,7 +14,7 @@ public class TestCaseGeneratorEncapsulationKeyCheck : ITestCaseGeneratorAsync<Te
 {
     private readonly IOracle _oracle;
     
-    public int NumberOfTestCasesToGenerate => 10;
+    public int NumberOfTestCasesToGenerate => 20;
 
     public TestCaseGeneratorEncapsulationKeyCheck(IOracle oracle)
     {

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/v1_0/EncapDecap/TestCaseExpectations/DecapsulationKeyExpectationProvider.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/v1_0/EncapDecap/TestCaseExpectations/DecapsulationKeyExpectationProvider.cs
@@ -12,7 +12,9 @@ public class DecapsulationKeyExpectationProvider : TestCaseExpectationProviderBa
         var expectationReasons = new List<MLKEMDecapsulationKeyDisposition>
         {
             { MLKEMDecapsulationKeyDisposition.None, 5 },
-            { MLKEMDecapsulationKeyDisposition.ModifyH, 5}
+            { MLKEMDecapsulationKeyDisposition.ModifyH, 5},
+            { MLKEMDecapsulationKeyDisposition.TooShort, 5 },
+            { MLKEMDecapsulationKeyDisposition.TooLong, 5 }
         };
         
         LoadExpectationReasons(expectationReasons);

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/v1_0/EncapDecap/TestCaseExpectations/EncapsulationKeyExpectationProvider.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/v1_0/EncapDecap/TestCaseExpectations/EncapsulationKeyExpectationProvider.cs
@@ -12,7 +12,9 @@ public class EncapsulationKeyExpectationProvider : TestCaseExpectationProviderBa
         var expectationReasons = new List<MLKEMEncapsulationKeyDisposition>
         {
             { MLKEMEncapsulationKeyDisposition.None, 5 },
-            { MLKEMEncapsulationKeyDisposition.ValuesTooLarge, 5 }
+            { MLKEMEncapsulationKeyDisposition.ValuesTooLarge, 5 },
+            { MLKEMEncapsulationKeyDisposition.TooShort, 5 },
+            { MLKEMEncapsulationKeyDisposition.TooLong, 5 }
         };
 
         LoadExpectationReasons(expectationReasons);

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/v1_0/EncapDecap/TestCaseGeneratorDecapsulationKeyCheck.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/v1_0/EncapDecap/TestCaseGeneratorDecapsulationKeyCheck.cs
@@ -14,7 +14,7 @@ public class TestCaseGeneratorDecapsulationKeyCheck : ITestCaseGeneratorAsync<Te
 {
     private readonly IOracle _oracle;
     
-    public int NumberOfTestCasesToGenerate => 10;
+    public int NumberOfTestCasesToGenerate => 20;
 
     public TestCaseGeneratorDecapsulationKeyCheck(IOracle oracle)
     {

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/v1_0/EncapDecap/TestCaseGeneratorEncapsulationKeyCheck.cs
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/ML-KEM/FIPS203/v1_0/EncapDecap/TestCaseGeneratorEncapsulationKeyCheck.cs
@@ -14,7 +14,7 @@ public class TestCaseGeneratorEncapsulationKeyCheck : ITestCaseGeneratorAsync<Te
 {
     private readonly IOracle _oracle;
     
-    public int NumberOfTestCasesToGenerate => 10;
+    public int NumberOfTestCasesToGenerate => 20;
 
     public TestCaseGeneratorEncapsulationKeyCheck(IOracle oracle)
     {

--- a/gen-val/src/oracle/src/NIST.CVP.ACVTS.Libraries.Oracle.Abstractions/DispositionTypes/MLKEMDecapsulationKeyDisposition.cs
+++ b/gen-val/src/oracle/src/NIST.CVP.ACVTS.Libraries.Oracle.Abstractions/DispositionTypes/MLKEMDecapsulationKeyDisposition.cs
@@ -8,5 +8,11 @@ public enum MLKEMDecapsulationKeyDisposition
     None,
     
     [EnumMember(Value = "modified H")]
-    ModifyH
+    ModifyH,
+
+    [EnumMember(Value = "invalid decapsulation key - too short")]
+    TooShort,
+
+    [EnumMember(Value = "invalid decapsulation key - too long")]
+    TooLong
 }

--- a/gen-val/src/oracle/src/NIST.CVP.ACVTS.Libraries.Oracle.Abstractions/DispositionTypes/MLKEMEncapsulationKeyDisposition.cs
+++ b/gen-val/src/oracle/src/NIST.CVP.ACVTS.Libraries.Oracle.Abstractions/DispositionTypes/MLKEMEncapsulationKeyDisposition.cs
@@ -9,4 +9,10 @@ public enum MLKEMEncapsulationKeyDisposition
     
     [EnumMember(Value = "noisy linear system values too large")]
     ValuesTooLarge,
+
+    [EnumMember(Value = "invalid encapsulation key - too short")]
+    TooShort,
+
+    [EnumMember(Value = "invalid encapsulation key - too long")]
+    TooLong,
 }

--- a/gen-val/src/orleans/src/NIST.CVP.ACVTS.Libraries.Orleans.Grains/Pqc/OracleObserverMLKEMDecapKeyCheckCaseGrain.cs
+++ b/gen-val/src/orleans/src/NIST.CVP.ACVTS.Libraries.Orleans.Grains/Pqc/OracleObserverMLKEMDecapKeyCheckCaseGrain.cs
@@ -5,6 +5,7 @@ using NIST.CVP.ACVTS.Libraries.Crypto.Common.Hash.ShaWrapper;
 using NIST.CVP.ACVTS.Libraries.Crypto.MLKEM;
 using NIST.CVP.ACVTS.Libraries.Math;
 using NIST.CVP.ACVTS.Libraries.Math.Entropy;
+using NIST.CVP.ACVTS.Libraries.Math.Helpers;
 using NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.DispositionTypes;
 using NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.ParameterTypes.ML_KEM;
 using NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.ResultTypes.ML_KEM;
@@ -56,6 +57,16 @@ public class OracleObserverMLKEMDecapKeyCheckCaseGrain : ObservableOracleGrainBa
             case MLKEMDecapsulationKeyDisposition.ModifyH:
                 // Modify the values in dk so that ek || H(ek) no longer matches
                 key.dk = new BadDecapsulationKeyManipulator(mlkem as MLKEM).ManipulateDecapsulationKey(key.dk);
+                break;
+            
+            case MLKEMDecapsulationKeyDisposition.TooShort:
+                // Drop the last byte, dk is no longer 768k + 96 bytes
+                key.dk = key.dk[..^1];
+                break;
+            
+            case MLKEMDecapsulationKeyDisposition.TooLong:
+                // Append a byte, dk is no longer 768k + 96 bytes
+                key.dk = key.dk.Concatenate(new byte[] { 0xAA });
                 break;
             
             default:

--- a/gen-val/src/orleans/src/NIST.CVP.ACVTS.Libraries.Orleans.Grains/Pqc/OracleObserverMLKEMEncapKeyCheckCaseGrain.cs
+++ b/gen-val/src/orleans/src/NIST.CVP.ACVTS.Libraries.Orleans.Grains/Pqc/OracleObserverMLKEMEncapKeyCheckCaseGrain.cs
@@ -5,6 +5,7 @@ using NIST.CVP.ACVTS.Libraries.Crypto.Common.Hash.ShaWrapper;
 using NIST.CVP.ACVTS.Libraries.Crypto.MLKEM;
 using NIST.CVP.ACVTS.Libraries.Math;
 using NIST.CVP.ACVTS.Libraries.Math.Entropy;
+using NIST.CVP.ACVTS.Libraries.Math.Helpers;
 using NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.DispositionTypes;
 using NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.ParameterTypes.ML_KEM;
 using NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.ResultTypes.ML_KEM;
@@ -56,6 +57,16 @@ public class OracleObserverMLKEMEncapKeyCheckCaseGrain : ObservableOracleGrainBa
             case MLKEMEncapsulationKeyDisposition.ValuesTooLarge:
                 // Modify the values in ek to be larger than q
                 key.ek = new BadEncapsulationKeyManipulator(mlkem as MLKEM).ManipulateEncapsulationKey(key.ek);
+                break;
+            
+            case MLKEMEncapsulationKeyDisposition.TooShort:
+                // Drop the last byte, ek is no longer 384k + 32 bytes
+                key.ek = key.ek[..^1];
+                break;
+            
+            case MLKEMEncapsulationKeyDisposition.TooLong:
+                // Append a byte, ek is no longer 384k + 32 bytes
+                key.ek = key.ek.Concatenate(new byte[] { 0xAA });
                 break;
             
             default:


### PR DESCRIPTION
Implements the two key check members proposed in #468. The short and long directions are separate members rather than the single WrongLength member suggested there, kept that way after discussion on the issue so a failing run says which direction an implementation got wrong. The ciphertext member is deferred, also per that discussion.

## What is missing

FIPS 203 puts a length check ahead of the content check in both input validation paths: section 7.2 requires `ek` to be exactly `384k + 32` bytes before the modulus check applies, and section 7.3 requires `dk` to be exactly `768k + 96` bytes before the `H(ek)` check applies. `MLKEM.cs` implements both (`EncapsulationKeyCheck` line 81, `DecapsulationKeyCheck` line 101).

No published vector reaches either one. All 210 values in the `encapsulationKeyCheck`, `decapsulationKeyCheck` and `decapsulation` validation groups across `ML-KEM-encapDecap-FIPS203` and `-tr1` are exactly the standard length, so an implementation that skipped the length check entirely and went straight to the content check would still pass every case.

Worth noting that the gap moved rather than appeared. Before the fix in #460 the negative `encapsulationKeyCheck` vectors were `384(k+1) + 64` bytes, so they failed on length and the modulus check was the one never exercised. Correcting them to standard length made the modulus check live and left the length check dead. Both want a case.

## What this does

- `TooShort` and `TooLong` on `MLKEMEncapsulationKeyDisposition` and `MLKEMDecapsulationKeyDisposition`, dropping or appending one byte in the two key check grains.
- Wired through both the `v1_0` and `tr1` expectation providers.
- Case count per key check group goes from 10 to 20, keeping the existing five occurrences per disposition. Those generators hold the count as a constant rather than reading `ExpectationCount`, so it is set explicitly. Easy to dial down if 20 is more than wanted; the coverage only needs one case per parameter set.
- Length modification is done inline in the grains rather than as a manipulator class, matching how SLH-DSA handles `ModifySignatureTooLarge` and `ModifySignatureTooSmall`. The existing ML-KEM manipulators exist because those manipulations need to decode and re-encode; a length change does not.

## Verification

- New unit tests assert that both key checks reject a key that is one byte short and one byte long, and still accept the unmodified key, for all three parameter sets. The tests call the server's own `EncapsulationKeyCheck` and `DecapsulationKeyCheck`, which matters here: as measured on #468, most library APIs cannot even be handed a wrong-length key, so the server's check functions are where these cases are observable and the unmodified-key positive control carries the weight. ML-KEM crypto suite: 118 passing, 0 failures.
- Full generation test suite: 7672 passing, 0 failures.
- Keys produced through the same path the grains use were checked against an independent Python implementation of FIPS 203 written from the standard text: 12 of 12 are rejected by the section 7.2 and 7.3 type checks, where the current published set has 210 of 210 at standard length and therefore no coverage at all.

## Not included

The ciphertext length check in section 7.3, implemented as `CiphertextCheck`. The `decapsulation` test type answers with a shared secret and no pass or fail, and a wrong-length ciphertext is rejected before any secret exists, so there is nothing to put in `k`. That is a schema decision rather than a member-naming one, as agreed on #468. Happy to follow up on it separately once that shape is decided.